### PR TITLE
Bug fixes

### DIFF
--- a/scripts/plugins/midiqol.js
+++ b/scripts/plugins/midiqol.js
@@ -37,7 +37,7 @@ export default {
 				if (rolledItem !== workflow.item) return true;
 				rollConfig.data.numberOfMinions = numberOfMinions;
 				const containsNumberOfMinions = rollConfig.parts.some(part => part[0].includes(CONSTANTS.NUMBER_MINIONS_BONUS))
-				if(!containsNumberOfMinions) rollConfig.parts.push(CONSTANTS.NUMBER_MINIONS_BONUS);
+				if(!containsNumberOfMinions) rollConfig.parts.push(numberOfMinions > 1 ? CONSTANTS.NUMBER_MINIONS_BONUS : '');
 				Hooks.off("dnd5e.preRollAttack", attackHookId);
 				return true;
 			});
@@ -77,7 +77,7 @@ export default {
 
 			const damageHookId = Hooks.on("dnd5e.preRollDamage", (rolledItem, rollConfig) => {
 				if (rolledItem !== workflow.item) return true;
-				rollConfig.data.numberOfMinions = numberOfMinions;
+				rollConfig.data.numberOfMinions = Math.max(0, numberOfMinions - 1);
 				rollConfig.parts = lib.patchItemDamageRollConfig(workflow.item);
 				Hooks.off("dnd5e.preRollDamage", damageHookId);
 				return true;

--- a/scripts/plugins/vanilla.js
+++ b/scripts/plugins/vanilla.js
@@ -43,8 +43,9 @@ export default {
 
 				rollConfig.data.numberOfMinions = numberOfMinions;
 				if (lib.getSetting(CONSTANTS.SETTING_KEYS.ENABLE_GROUP_ATTACK_BONUS)) {
-					const containsNumberOfMinions = rollConfig.parts.some(part => part[0].includes(CONSTANTS.NUMBER_MINIONS_BONUS))
-					if (!containsNumberOfMinions) rollConfig.parts.push(CONSTANTS.NUMBER_MINIONS_BONUS);
+					const containsNumberOfMinions = rollConfig.parts.includes(CONSTANTS.NUMBER_MINIONS_BONUS);
+					rollConfig.parts = [];
+					if (!containsNumberOfMinions) rollConfig.parts.push(numberOfMinions > 1 ? CONSTANTS.NUMBER_MINIONS_BONUS : '');
 				}
 
 				item.rollAttack(rollConfig);
@@ -64,7 +65,7 @@ export default {
 
 			if (minionAttacks?.[item.parent.uuid] && minionAttacks?.[item.parent.uuid].attacked) {
 
-				rollConfig.data.numberOfMinions = minionAttacks[item.parent.uuid].numberOfMinions;
+				rollConfig.data.numberOfMinions = Math.max(0, minionAttacks[item.parent.uuid].numberOfMinions - 1);
 				rollConfig.parts = lib.patchItemDamageRollConfig(item);
 
 				delete minionAttacks[item.parent.uuid];


### PR DESCRIPTION
Howdy. This ought to fix #7. 
Changes:
- Midi & Vanilla: Only give attack bonus if >1 minion attacking
- Midi & Vanilla: Damage patched is in addition to normally "rolled" damage, so should be multiplied by (numMinions - 1), since the initiator of the attack will be adding their individual "roll"
- Vanilla: Looks like `rollConfig.parts` gets ADDED to the item's attack parts, so gotta wipe that prior to calling `rollAttack(rollConfig)` - still adding in the new numMinions constant if not already present.